### PR TITLE
Maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,28 @@
 ---
 
-sudo: required
-
-language: python
-python:
-  - "2.7"
-
-services: docker
-
+before_install:
+  - "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+  - "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\""
+  - "sudo apt-get update"
+  - "sudo apt-get -y install docker-ce"
 branches:
   only:
     - "master"
-
-before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce
-
 env:
   global:
-    - IMAGE=irap/docker-debian-ansible:stretch
+    - "IMAGE=irap/docker-debian-ansible:stretch"
   matrix:
-    - ANSIBLE_VERSION=2.4.0.0
-    - ANSIBLE_VERSION=2.3.2.0
-    - ANSIBLE_VERSION=2.2.3.0
-    - ANSIBLE_VERSION=2.1.6.0
-
+    - "ANSIBLE_VERSION=2.4.1.0"
+    - "ANSIBLE_VERSION=2.3.2.0"
+    - "ANSIBLE_VERSION=2.2.3.0"
+language: "python"
+notifications:
+  email: false
+python:
+  - "2.7"
 script:
-  - wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh
-  - chmod +x ${PWD}/run.sh
-  - ${PWD}/run.sh
+  - "wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh"
+  - "chmod +x ${PWD}/run.sh"
+  - "${PWD}/run.sh"
+services: "docker"
+sudo: "required"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ Currently this role is developed for and tested on Debian GNU/Linux (release: st
 
 Ansible version compatibility:
 
-- __2.4.0.0__ (current version in use for development of this role) 
+- __2.4.1.0__ (current version in use for development of this role)
 - 2.3.2.0
 - 2.2.3.0
-- 2.1.6.0
 
 ## Example
 
@@ -47,7 +46,6 @@ Ansible version compatibility:
     - role: "ansible-keepalived"
       tags:
         - "keepalived"
-
 ```
 
 ## Defaults

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ VM_GROUP_NAME = "group"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..VM_COUNT).each do |i|
     config.vm.define "#{VM_BASE_NAME}#{i}" do |subconfig|
-      subconfig.vm.box = ENV['VAGRANT_CONFIG_VM_BOX'] || 'parallels/debian-9.1'
+      subconfig.vm.box = ENV['VAGRANT_CONFIG_VM_BOX'] || 'parallels/debian-9.2'
       subconfig.vm.hostname = (i == 1) ? HN : HN + i.to_s
 
       subconfig.vm.provider "parallels" do |prl|

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - "vip"
     - "vrrp"
   license: "MIT"
-  min_ansible_version: "2.1.6.0"
+  min_ansible_version: "2.2.3.0"
   platforms:
     - name: "Debian"
       versions:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,3 +23,4 @@
     name: "{{ keepalived_service_name }}"
     state: "started"
     enabled: "yes"
+    use: "systemd"


### PR DESCRIPTION
Drop "Ansible==2.1.6.0"-support
Add "Ansible==2.4.1.0" as test target
Perform small cosmetic refactoring on .travis.yml
Bump Vagrantfile's default Debian version to '9.2'